### PR TITLE
[BUGFIX] COLOR-210 Pencil pusher projectiles don't despawn.

### DIFF
--- a/Assets/Runtime/Decals/PencilDecal.prefab
+++ b/Assets/Runtime/Decals/PencilDecal.prefab
@@ -60,8 +60,7 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 9187825299197032943, guid: fd7bddb1d3151334c8dda37e1e98e191, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Runtime/Weapons/Projectiles/Pencil.prefab
+++ b/Assets/Runtime/Weapons/Projectiles/Pencil.prefab
@@ -12,6 +12,10 @@ PrefabInstance:
       propertyPath: spawnObj
       value: 
       objectReference: {fileID: 544857716886652588, guid: 7b6e7b3eef90399438a6b65f1b040e86, type: 3}
+    - target: {fileID: -5477002098782717127, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
+      propertyPath: spawnObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 544857716886652588, guid: 7b6e7b3eef90399438a6b65f1b040e86, type: 3}
     - target: {fileID: -4901289499542378357, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
       propertyPath: damageToInflict
       value: 30
@@ -27,6 +31,10 @@ PrefabInstance:
     - target: {fileID: 6602228063636873149, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
       propertyPath: m_Name
       value: Pencil
+      objectReference: {fileID: 0}
+    - target: {fileID: 6833573927129456460, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
+      propertyPath: minimumSpeed
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7054305264628404065, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -68,7 +76,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -5477002098782717127, guid: 28b0562a0f396344bbc52742521c26e1, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []


### PR DESCRIPTION
There was no "pencil decal", so the "Spawn Decal on Destroy" script couldn't fire, so they wouldn't destruct. I made one in case we wish to implement such a thing, then removed the problematic script from pencil projectiles.